### PR TITLE
대댓글 기능 구현을 위한 Entity 수정 및 DTO 구현

### DIFF
--- a/src/main/java/com/example/Triple_clone/domain/entity/Review.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/Review.java
@@ -6,6 +6,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -24,6 +27,13 @@ public class Review {
 
     private String content;
     private Image image;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Review parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> children = new ArrayList<>();
 
     public Review(Member member, Recommendation recommendation, String content) {
         this.member = member;

--- a/src/main/java/com/example/Triple_clone/domain/entity/Review.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/Review.java
@@ -46,6 +46,10 @@ public class Review {
         return image.getStoredFileName();
     }
 
+    public void update(String content) {
+        this.content = content;
+    }
+
     public void addChildReview(Review child) {
         children.add(child);
         child.parent = this;

--- a/src/main/java/com/example/Triple_clone/domain/entity/Review.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/Review.java
@@ -1,6 +1,7 @@
 package com.example.Triple_clone.domain.entity;
 
 import com.example.Triple_clone.domain.vo.Image;
+import com.example.Triple_clone.domain.vo.ReviewStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -35,6 +36,9 @@ public class Review {
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> children = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    private ReviewStatus status = ReviewStatus.ACTIVE;
+
     public Review(Member member, Recommendation recommendation, String content) {
         this.member = member;
         this.recommendation = recommendation;
@@ -57,5 +61,13 @@ public class Review {
 
     public boolean isRoot() {
         return parent == null;
+    }
+
+    public void softDelete() {
+        this.status = ReviewStatus.DELETED;
+    }
+
+    public boolean isDeleted() {
+        return this.status == ReviewStatus.DELETED;
     }
 }

--- a/src/main/java/com/example/Triple_clone/domain/entity/Review.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/Review.java
@@ -45,4 +45,13 @@ public class Review {
         this.image = image;
         return image.getStoredFileName();
     }
+
+    public void addChildReview(Review child) {
+        children.add(child);
+        child.parent = this;
+    }
+
+    public boolean isRoot() {
+        return parent == null;
+    }
 }

--- a/src/main/java/com/example/Triple_clone/domain/entity/Review.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/Review.java
@@ -59,6 +59,10 @@ public class Review {
         child.parent = this;
     }
 
+    public String getWriter() {
+        return member.getName();
+    }
+
     public boolean isRoot() {
         return parent == null;
     }

--- a/src/main/java/com/example/Triple_clone/domain/vo/ReviewStatus.java
+++ b/src/main/java/com/example/Triple_clone/domain/vo/ReviewStatus.java
@@ -1,0 +1,7 @@
+package com.example.Triple_clone.domain.vo;
+
+public enum ReviewStatus {
+    ACTIVE,
+    DELETED
+}
+

--- a/src/main/java/com/example/Triple_clone/dto/recommend/user/RecommendWriteReviewDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/recommend/user/RecommendWriteReviewDto.java
@@ -11,7 +11,8 @@ public record RecommendWriteReviewDto(
         long placeId,
         @NotBlank(message = "There is no contents")
         @Size(max = 3000, message = "maximum contents size is 3000 words")
-        String content) {
+        String content,
+        Long parentId) {
     public Review toEntity(Member member, Recommendation recommendation) {
         return new Review(member, recommendation, this.content);
     }

--- a/src/main/java/com/example/Triple_clone/dto/recommend/user/RecommendWriteReviewDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/recommend/user/RecommendWriteReviewDto.java
@@ -13,7 +13,11 @@ public record RecommendWriteReviewDto(
         @Size(max = 3000, message = "maximum contents size is 3000 words")
         String content,
         Long parentId) {
-    public Review toEntity(Member member, Recommendation recommendation) {
-        return new Review(member, recommendation, this.content);
+    public Review toEntity(Member member, Recommendation recommendation, Review parent) {
+        Review review = new Review(member, recommendation, this.content);
+        if (parent != null) {
+            parent.addChildReview(review);
+        }
+        return review;
     }
 }

--- a/src/main/java/com/example/Triple_clone/dto/review/ReviewResponseDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/review/ReviewResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.Triple_clone.dto.review;
+
+import com.example.Triple_clone.domain.entity.Review;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ReviewResponseDto {
+    private Long id;
+    private String content;
+    private List<ReviewResponseDto> replies;
+
+    public ReviewResponseDto(Review review) {
+        this.id = review.getId();
+        this.content = review.getContent();
+        this.replies = review.getChildren()
+                .stream()
+                .map(ReviewResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/Triple_clone/dto/review/ReviewResponseDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/review/ReviewResponseDto.java
@@ -1,21 +1,17 @@
 package com.example.Triple_clone.dto.review;
 
 import com.example.Triple_clone.domain.entity.Review;
+import lombok.Getter;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+@Getter
 public class ReviewResponseDto {
     private Long id;
+    private String writer;
     private String content;
-    private List<ReviewResponseDto> replies;
 
     public ReviewResponseDto(Review review) {
         this.id = review.getId();
+        this.writer = review.getWriter();
         this.content = review.getContent();
-        this.replies = review.getChildren()
-                .stream()
-                .map(ReviewResponseDto::new)
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/Triple_clone/dto/review/ReviewUpdateDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/review/ReviewUpdateDto.java
@@ -1,0 +1,7 @@
+package com.example.Triple_clone.dto.review;
+
+public record ReviewUpdateDto(
+        long reviewId,
+        String content
+) {
+}

--- a/src/main/java/com/example/Triple_clone/dto/review/RootReviewResponseDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/review/RootReviewResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.Triple_clone.dto.review;
+
+import com.example.Triple_clone.domain.entity.Review;
+import lombok.Getter;
+
+@Getter
+public class RootReviewResponseDto {
+    private ReviewResponseDto reviewResponseDto;
+    private int replyCount;
+
+    public RootReviewResponseDto(Review review) {
+        this.reviewResponseDto = new ReviewResponseDto(review);
+        this.replyCount = (int) review.getChildren().stream()
+                .filter(child -> !child.isDeleted())
+                .count();
+    }
+}

--- a/src/main/java/com/example/Triple_clone/repository/ReviewRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/ReviewRepository.java
@@ -1,7 +1,13 @@
 package com.example.Triple_clone.repository;
 
 import com.example.Triple_clone.domain.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Page<Review> findByParentIsNullAndRecommendationIdAndDeletedFalseOrderByIdDesc(Long recommendationId, Pageable pageable);
+
+    Page<Review> findByParentIdAndDeletedFalseOrderByIdAsc(Long parentId, Pageable pageable);
+
 }

--- a/src/main/java/com/example/Triple_clone/service/review/ReviewFacadeService.java
+++ b/src/main/java/com/example/Triple_clone/service/review/ReviewFacadeService.java
@@ -31,6 +31,10 @@ public class ReviewFacadeService {
         Review parent = null;
         if (writeReviewRequestDto.parentId() != null) {
             parent = reviewService.findById(writeReviewRequestDto.parentId());
+
+            if (parent.getParent() != null) {
+                throw new IllegalArgumentException("대댓글은 depth가 2이상 허용되지 않습니다.");
+            }
         }
 
         Review review = writeReviewRequestDto.toEntity(member, recommendation, parent);

--- a/src/main/java/com/example/Triple_clone/service/review/ReviewFacadeService.java
+++ b/src/main/java/com/example/Triple_clone/service/review/ReviewFacadeService.java
@@ -27,7 +27,13 @@ public class ReviewFacadeService {
     public void writeReview(RecommendWriteReviewDto writeReviewRequestDto) {
         Recommendation recommendation = recommendService.findById(writeReviewRequestDto.placeId());
         Member member = userService.findById(writeReviewRequestDto.userId());
-        Review review = writeReviewRequestDto.toEntity(member, recommendation);
+
+        Review parent = null;
+        if (writeReviewRequestDto.parentId() != null) {
+            parent = reviewService.findById(writeReviewRequestDto.parentId());
+        }
+
+        Review review = writeReviewRequestDto.toEntity(member, recommendation, parent);
 
         reviewService.save(review);
         recommendation.addReview(review);

--- a/src/main/java/com/example/Triple_clone/service/review/ReviewService.java
+++ b/src/main/java/com/example/Triple_clone/service/review/ReviewService.java
@@ -1,8 +1,12 @@
 package com.example.Triple_clone.service.review;
 
 import com.example.Triple_clone.domain.entity.Review;
+import com.example.Triple_clone.dto.review.ReviewResponseDto;
+import com.example.Triple_clone.dto.review.RootReviewResponseDto;
 import com.example.Triple_clone.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
@@ -16,8 +20,28 @@ public class ReviewService {
         repository.save(review);
     }
 
+    public void delete(Review review) {
+        repository.delete(review);
+    }
+
+    public void update(Review review, String content) {
+        review.update(content);
+    }
+
     public Review findById(Long reviewId) {
         return repository.findById(reviewId)
                 .orElseThrow(NoSuchElementException::new);
+    }
+
+    public Page<RootReviewResponseDto> getRootReviews(Long recommendationId, Pageable pageable) {
+        return repository
+                .findByParentIsNullAndRecommendationIdAndDeletedFalseOrderByIdDesc(recommendationId, pageable)
+                .map(RootReviewResponseDto::new);
+    }
+
+    public Page<ReviewResponseDto> getReplies(Long parentId, Pageable pageable) {
+        return repository
+                .findByParentIdAndDeletedFalseOrderByIdAsc(parentId, pageable)
+                .map(ReviewResponseDto::new);
     }
 }

--- a/src/main/java/com/example/Triple_clone/web/controller/recommend/user/ReviewController.java
+++ b/src/main/java/com/example/Triple_clone/web/controller/recommend/user/ReviewController.java
@@ -1,12 +1,18 @@
 package com.example.Triple_clone.web.controller.recommend.user;
 
 import com.example.Triple_clone.dto.recommend.user.RecommendWriteReviewDto;
+import com.example.Triple_clone.dto.review.ReviewResponseDto;
+import com.example.Triple_clone.dto.review.ReviewUpdateDto;
+import com.example.Triple_clone.dto.review.RootReviewResponseDto;
 import com.example.Triple_clone.service.review.ReviewFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -29,6 +35,28 @@ public class ReviewController {
             @RequestBody @Validated RecommendWriteReviewDto writeReviewRequestDto) {
         service.writeReview(writeReviewRequestDto);
         return ResponseEntity.ok(writeReviewRequestDto);
+    }
+
+    @Operation(summary = "Root 리뷰 조회", description = "최상위 리뷰들을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청 형식입니다")
+    @ApiResponse(responseCode = "500", description = "내부 서버 오류 발생")
+    @GetMapping("/recommendation/review/{recommendationId}")
+    public ResponseEntity<Page<RootReviewResponseDto>> readReview(
+            @Parameter(description = "해당 게시물 ID", required = true)
+            @PathVariable Long recommendationId, @PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(service.getRootReviews(recommendationId, pageable));
+    }
+
+    @Operation(summary = "대댓글 조회", description = "대댓글을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청 형식입니다")
+    @ApiResponse(responseCode = "500", description = "내부 서버 오류 발생")
+    @GetMapping("/recommendation/reply/{parentId}")
+    public ResponseEntity<Page<ReviewResponseDto>> readReply(
+            @Parameter(description = "해당 게시물 ID", required = true)
+            @PathVariable Long parentId, @PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(service.getReplies(parentId, pageable));
     }
 
     @Operation(summary = "리뷰 사진 추가", description = "리뷰에 사진을 추가합니다")
@@ -59,5 +87,31 @@ public class ReviewController {
         return ResponseEntity.ok()
                 .contentType(MediaType.IMAGE_PNG)
                 .body(response);
+    }
+
+    @Operation(summary = "리뷰 수정", description = "리뷰의 내용을 수정합니다.")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청 형식입니다")
+    @ApiResponse(responseCode = "500", description = "내부 서버 오류 발생")
+    @ApiResponse(responseCode = "401", description = "권한 인증 오류 발생")
+    @PutMapping("/recommendation/review")
+    public ResponseEntity<ReviewResponseDto> updateReview(
+            @Parameter(description = "이미지를 로딩할 리뷰 ID", required = true)
+            @RequestBody ReviewUpdateDto updateDto, @RequestParam long memberId) {
+        ReviewResponseDto response = service.updateReview(updateDto, memberId);
+        return ResponseEntity.ok()
+                .body(response);
+    }
+
+    @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청 형식입니다")
+    @ApiResponse(responseCode = "500", description = "내부 서버 오류 발생")
+    @ApiResponse(responseCode = "401", description = "권한 인증 오류 발생")
+    @DeleteMapping("/recommendation/review/{reviewId}")
+    public ResponseEntity<Void> deleteReview(
+            @Parameter(description = "삭제할 리뷰 ID", required = true)
+            @PathVariable long reviewId, @RequestParam long memberId) {
+        service.deleteReview(reviewId, memberId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/test/java/com/example/Triple_clone/domain/dto/recommend/user/RecommendWriteReviewDtoTest.java
+++ b/src/test/java/com/example/Triple_clone/domain/dto/recommend/user/RecommendWriteReviewDtoTest.java
@@ -23,7 +23,7 @@ public class RecommendWriteReviewDtoTest {
     @Test
     void 리뷰_작성_DTO_유효성_성공() {
         RecommendWriteReviewDto dto = new RecommendWriteReviewDto(
-                1L, 1L, "test content");
+                1L, 1L, "test content", null);
 
         Set<ConstraintViolation<RecommendWriteReviewDto>> violations = validator.validate(dto);
         assertThat(violations).isEmpty();
@@ -32,7 +32,7 @@ public class RecommendWriteReviewDtoTest {
     @Test
     void 리뷰_작성_DTO_유효성_실패_내용_null() {
         RecommendWriteReviewDto dto = new RecommendWriteReviewDto(
-                1L, 1L, null);
+                1L, 1L, null, null);
 
         Set<ConstraintViolation<RecommendWriteReviewDto>> violations = validator.validate(dto);
         assertThat(violations).hasSize(1);
@@ -48,7 +48,7 @@ public class RecommendWriteReviewDtoTest {
         }
 
         RecommendWriteReviewDto dto = new RecommendWriteReviewDto(
-                1L, 1L, String.valueOf(overContent));
+                1L, 1L, String.valueOf(overContent), null);
 
         Set<ConstraintViolation<RecommendWriteReviewDto>> violations = validator.validate(dto);
         assertThat(violations).hasSize(1);

--- a/src/test/java/com/example/Triple_clone/service/review/ReviewFacadeServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/review/ReviewFacadeServiceTest.java
@@ -6,9 +6,12 @@ import com.example.Triple_clone.domain.entity.Review;
 import com.example.Triple_clone.domain.vo.Image;
 import com.example.Triple_clone.domain.vo.Location;
 import com.example.Triple_clone.dto.recommend.user.RecommendWriteReviewDto;
+import com.example.Triple_clone.dto.review.ReviewResponseDto;
+import com.example.Triple_clone.dto.review.ReviewUpdateDto;
 import com.example.Triple_clone.service.membership.UserService;
 import com.example.Triple_clone.service.recommend.user.RecommendService;
 import com.example.Triple_clone.service.support.FileManager;
+import com.example.Triple_clone.web.exception.RestApiException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
@@ -80,6 +84,99 @@ class ReviewFacadeServiceTest {
 
         assertEquals(1, parentReview.getChildren().size());
         assertEquals("대댓글입니다.", parentReview.getChildren().get(0).getContent());
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 성공")
+    void deleteReviewSuccess() {
+        Long reviewId = 1L;
+        Long memberId = 10L;
+
+        Member member = mock(Member.class);
+        Review review = mock(Review.class);
+
+        when(member.getId()).thenReturn(memberId);
+        when(review.getMember()).thenReturn(member);
+        when(review.getMember().getId()).thenReturn(memberId);
+        when(userService.findById(memberId)).thenReturn(member);
+        when(reviewService.findById(reviewId)).thenReturn(review);
+
+        facadeService.deleteReview(reviewId, memberId);
+
+        verify(reviewService).delete(review);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 실패 - 작성자 불일치")
+    void deleteReviewFail_Unauthorized() {
+        Long reviewId = 1L;
+        Long memberId = 10L;
+        Long otherMemberId = 99L;
+
+        Member member = mock(Member.class);
+        Member otherMember = mock(Member.class);
+        Review review = mock(Review.class);
+
+        when(member.getId()).thenReturn(memberId);
+        when(otherMember.getId()).thenReturn(otherMemberId);
+        when(review.getMember()).thenReturn(otherMember);
+        when(userService.findById(memberId)).thenReturn(member);
+        when(reviewService.findById(reviewId)).thenReturn(review);
+
+        assertThatThrownBy(() -> facadeService.deleteReview(reviewId, memberId))
+                .isInstanceOf(RestApiException.class);
+
+        verify(reviewService, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 성공")
+    void updateReviewSuccess() {
+        Long reviewId = 1L;
+        Long memberId = 10L;
+        String newContent = "Updated content";
+
+        Member member = mock(Member.class);
+        Review review = mock(Review.class);
+        ReviewUpdateDto updateDto = new ReviewUpdateDto(reviewId, newContent);
+
+        when(member.getId()).thenReturn(memberId);
+        when(review.getMember()).thenReturn(member);
+        when(review.getId()).thenReturn(reviewId);
+        when(review.getContent()).thenReturn(newContent);
+        when(userService.findById(memberId)).thenReturn(member);
+        when(reviewService.findById(reviewId)).thenReturn(review);
+
+        ReviewResponseDto response = facadeService.updateReview(updateDto, memberId);
+
+        verify(reviewService).update(review, newContent);
+        assertThat(response.getId()).isEqualTo(reviewId);
+        assertThat(response.getContent()).isEqualTo(newContent);
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 작성자 불일치")
+    void updateReviewFail_Unauthorized() {
+        Long reviewId = 1L;
+        Long memberId = 10L;
+        Long otherMemberId = 99L;
+
+        String newContent = "Updated content";
+        Member member = mock(Member.class);
+        Member otherMember = mock(Member.class);
+        Review review = mock(Review.class);
+        ReviewUpdateDto updateDto = new ReviewUpdateDto(reviewId, newContent);
+
+        when(member.getId()).thenReturn(memberId);
+        when(otherMember.getId()).thenReturn(otherMemberId);
+        when(review.getMember()).thenReturn(otherMember);
+        when(userService.findById(memberId)).thenReturn(member);
+        when(reviewService.findById(reviewId)).thenReturn(review);
+
+        assertThatThrownBy(() -> facadeService.updateReview(updateDto, memberId))
+                .isInstanceOf(RestApiException.class);
+
+        verify(reviewService, never()).update(any(), any());
     }
 
     @Test

--- a/src/test/java/com/example/Triple_clone/service/review/ReviewFacadeServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/review/ReviewFacadeServiceTest.java
@@ -4,6 +4,7 @@ import com.example.Triple_clone.domain.entity.Member;
 import com.example.Triple_clone.domain.entity.Recommendation;
 import com.example.Triple_clone.domain.entity.Review;
 import com.example.Triple_clone.domain.vo.Image;
+import com.example.Triple_clone.domain.vo.Location;
 import com.example.Triple_clone.dto.recommend.user.RecommendWriteReviewDto;
 import com.example.Triple_clone.service.membership.UserService;
 import com.example.Triple_clone.service.recommend.user.RecommendService;
@@ -13,7 +14,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 class ReviewFacadeServiceTest {
@@ -51,6 +55,31 @@ class ReviewFacadeServiceTest {
 
         verify(reviewService).save(review);
         verify(recommendation).addReview(review);
+    }
+
+    @Test
+    @DisplayName("대댓글 작성 성공")
+    void writeReplyReviewSuccess() {
+        Member member = new Member("test", "test", "test", new ArrayList<>());
+        Recommendation recommendation = new Recommendation("test", "test", "test", new Location());
+        Review parentReview = new Review(member, recommendation, "부모 댓글");
+
+        RecommendWriteReviewDto dto = new RecommendWriteReviewDto(
+                1L,
+                100L,
+                "대댓글입니다.",
+                parentReview.getId()
+        );
+
+        // mocking
+        when(userService.findById(1L)).thenReturn(member);
+        when(recommendService.findById(100L)).thenReturn(recommendation);
+        when(reviewService.findById(anyLong())).thenReturn(parentReview);
+
+        facadeService.writeReview(dto);
+
+        assertEquals(1, parentReview.getChildren().size());
+        assertEquals("대댓글입니다.", parentReview.getChildren().get(0).getContent());
     }
 
     @Test

--- a/src/test/java/com/example/Triple_clone/service/review/ReviewFacadeServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/review/ReviewFacadeServiceTest.java
@@ -45,7 +45,7 @@ class ReviewFacadeServiceTest {
         when(dto.placeId()).thenReturn(100L);
         when(userService.findById(1L)).thenReturn(member);
         when(recommendService.findById(100L)).thenReturn(recommendation);
-        when(dto.toEntity(member, recommendation)).thenReturn(review);
+        when(dto.toEntity(member, recommendation, null)).thenReturn(review);
 
         facadeService.writeReview(dto);
 


### PR DESCRIPTION
## 대댓글 기능을 구현하기 위해 자기참조 형식과 List를 사용하여 트리구조로 저장하도록 함

- isRoot 메서드를 이용하여 자신이 root 댓글인지 판별 가능
- addChildReview 메서드를 이용하여 대댓글 저장
- cascade = CascadeType.ALL, orphanRemoval = true 옵션을 사용하여, 댓글 삭제시 대댓글도 함께 삭제
- 상속이나 합성을 사용하지 않고 Review Entity를 직접 수정한 이유
    - 부모 댓글과 자식 댓글이 동일한 타입이기 때문에
    - 트리 구조가 객체 모델에 자연스럽게 반영됨
    - 매핑과 쿼리 작성이 단순하고 효율적
    - 구조가 간단하고 직관적임

- Entity 직접 반환시 순환참조 문제 발생 가능성이 있기 때문에 DTO로 변경하여 return 하도록 DTO 생성