### PR TITLE
신고 관리자 기능 추가 (신고 목록, 카운트, 승인/거절) PR

### DIFF
--- a/src/main/java/com/example/Triple_clone/configuration/QuerydslConfig.java
+++ b/src/main/java/com/example/Triple_clone/configuration/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.example.Triple_clone.configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/Triple_clone/dto/report/ReportCountDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/report/ReportCountDto.java
@@ -1,0 +1,13 @@
+package com.example.Triple_clone.dto.report;
+
+public class ReportCountDto {
+    private Long targetId;
+    private String targetType;
+    private Long reportCount;
+
+    public ReportCountDto(Long targetId, String targetType, Long reportCount) {
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.reportCount = reportCount;
+    }
+}

--- a/src/main/java/com/example/Triple_clone/dto/report/ReportCountDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/report/ReportCountDto.java
@@ -1,5 +1,8 @@
 package com.example.Triple_clone.dto.report;
 
+import lombok.Getter;
+
+@Getter
 public class ReportCountDto {
     private Long targetId;
     private String targetType;

--- a/src/main/java/com/example/Triple_clone/repository/ReportCountRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/ReportCountRepository.java
@@ -1,0 +1,10 @@
+package com.example.Triple_clone.repository;
+
+import com.example.Triple_clone.domain.entity.ReportCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportCountRepository extends JpaRepository<ReportCount, Long> {
+    Optional<ReportCount> findByTargetIdAndTargetType(Long targetId, String targetType);
+}

--- a/src/test/java/com/example/Triple_clone/domain/dto/ReportRequestDtoTest.java
+++ b/src/test/java/com/example/Triple_clone/domain/dto/ReportRequestDtoTest.java
@@ -1,6 +1,7 @@
-package com.example.Triple_clone.dto.report;
+package com.example.Triple_clone.domain.dto;
 
 import com.example.Triple_clone.domain.vo.ReportingReason;
+import com.example.Triple_clone.dto.report.ReportRequestDto;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/example/Triple_clone/service/report/ReportServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/report/ReportServiceTest.java
@@ -5,6 +5,7 @@ import com.example.Triple_clone.domain.entity.Review;
 import com.example.Triple_clone.domain.vo.ReportTargetType;
 import com.example.Triple_clone.domain.vo.ReportingReason;
 import com.example.Triple_clone.repository.MemberRepository;
+import com.example.Triple_clone.repository.ReportCountRepository;
 import com.example.Triple_clone.repository.ReportRepository;
 import com.example.Triple_clone.repository.ReviewRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,9 @@ public class ReportServiceTest {
 
     @Mock
     private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReportCountRepository reportCountRepository;
 
     @InjectMocks
     private ReportService reportService;


### PR DESCRIPTION
## 관리자가 신고 목록을 조회하고, 신고를 승인/거절하며, 신고 카운트를 확인할 수 있는 기능을 추가했습니다.

### 변경사항
- 신고 목록 조회: 페이징 및 조건 필터링 적용

- 신고 카운트 조회: 신고 대상 별 카운트 확인, 필터링

- 특정 요소 신고 리스트: targetId, targetType으로 신고 목록 조회

- 신고 승인/거절: 신고에 대한 승인 및 거절 처리 기능 추가


#### Querydsl을 사용하여 동적 조회가 가능하도록 설정함
#### 모든 조회의 page 크기는 10으로 고정함
#### 테스트 코드 수정 중 리뷰에 대한 테스트 코드 오류로 수정 및 추가 부분 있음


## ISSUE
https://github.com/piedra-de-flor/nomadic/issues/66
https://github.com/piedra-de-flor/nomadic/issues/67
https://github.com/piedra-de-flor/nomadic/issues/68