### PR TITLE
신고 관리자 기능 추가 (신고 목록, 카운트, 승인/거절) PR

### DIFF
--- a/src/main/java/com/example/Triple_clone/configuration/QuerydslConfig.java
+++ b/src/main/java/com/example/Triple_clone/configuration/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.example.Triple_clone.configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/Triple_clone/domain/entity/Report.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/Report.java
@@ -1,5 +1,6 @@
 package com.example.Triple_clone.domain.entity;
 
+import com.example.Triple_clone.domain.vo.ReportStatus;
 import com.example.Triple_clone.domain.vo.ReportingReason;
 import jakarta.persistence.*;
 import lombok.*;
@@ -33,6 +34,13 @@ public class Report {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportStatus status = ReportStatus.PENDING;
+
+    @Column
+    private LocalDateTime processedAt;
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
@@ -55,5 +63,15 @@ public class Report {
                 .reason(reason)
                 .detail(detail)
                 .build();
+    }
+
+    public void approve() {
+        this.status = ReportStatus.APPROVED;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        this.status = ReportStatus.REJECTED;
+        this.processedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/Triple_clone/domain/entity/ReportCount.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/ReportCount.java
@@ -1,0 +1,38 @@
+package com.example.Triple_clone.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportCount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Column(nullable = false)
+    private String targetType;
+
+    @Column(nullable = false)
+    private Long count;
+
+    public void incrementCount() {
+        this.count++;
+    }
+
+    @Builder
+    public ReportCount(Long targetId, String targetType, Long count) {
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.count = count;
+    }
+}
+

--- a/src/main/java/com/example/Triple_clone/domain/vo/ReportStatus.java
+++ b/src/main/java/com/example/Triple_clone/domain/vo/ReportStatus.java
@@ -1,0 +1,8 @@
+package com.example.Triple_clone.domain.vo;
+
+public enum ReportStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}
+

--- a/src/main/java/com/example/Triple_clone/dto/report/ReportCountDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/report/ReportCountDto.java
@@ -1,0 +1,13 @@
+package com.example.Triple_clone.dto.report;
+
+public class ReportCountDto {
+    private Long targetId;
+    private String targetType;
+    private Long reportCount;
+
+    public ReportCountDto(Long targetId, String targetType, Long reportCount) {
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.reportCount = reportCount;
+    }
+}

--- a/src/main/java/com/example/Triple_clone/dto/report/ReportCountDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/report/ReportCountDto.java
@@ -1,5 +1,8 @@
 package com.example.Triple_clone.dto.report;
 
+import lombok.Getter;
+
+@Getter
 public class ReportCountDto {
     private Long targetId;
     private String targetType;

--- a/src/main/java/com/example/Triple_clone/dto/report/ReportResponseDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/report/ReportResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.Triple_clone.dto.report;
+
+import com.example.Triple_clone.domain.vo.ReportStatus;
+import com.example.Triple_clone.domain.vo.ReportingReason;
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+
+public record ReportResponseDto(
+        Long id,
+        String targetType,
+        Long targetId,
+        String reporterName,
+        ReportingReason reason,
+        ReportStatus status,
+        LocalDateTime createdAt
+) {
+    @QueryProjection
+    public ReportResponseDto {
+    }
+}
+

--- a/src/main/java/com/example/Triple_clone/dto/report/ReportSearchDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/report/ReportSearchDto.java
@@ -1,0 +1,21 @@
+package com.example.Triple_clone.dto.report;
+
+import com.example.Triple_clone.domain.vo.ReportStatus;
+import com.example.Triple_clone.domain.vo.ReportingReason;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ReportSearchDto {
+    private String targetType;
+    private ReportStatus status;
+    private ReportingReason reason;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime fromDate;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime toDate;
+}

--- a/src/main/java/com/example/Triple_clone/repository/ReportAdminRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/ReportAdminRepository.java
@@ -1,0 +1,10 @@
+package com.example.Triple_clone.repository;
+
+import com.example.Triple_clone.dto.report.ReportResponseDto;
+import com.example.Triple_clone.dto.report.ReportSearchDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReportAdminRepository {
+    Page<ReportResponseDto> searchReports(ReportSearchDto condition, Pageable pageable);
+}

--- a/src/main/java/com/example/Triple_clone/repository/ReportAdminRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/ReportAdminRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReportAdminRepository {
     Page<ReportResponseDto> searchReports(ReportSearchDto condition, Pageable pageable);
+    Page<ReportResponseDto> searchReportsByTarget(String targetType, Long targetId, Pageable pageable);
 }

--- a/src/main/java/com/example/Triple_clone/repository/ReportAdminRepositoryImpl.java
+++ b/src/main/java/com/example/Triple_clone/repository/ReportAdminRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.example.Triple_clone.repository;
+
+import com.example.Triple_clone.domain.entity.QMember;
+import com.example.Triple_clone.domain.entity.QReport;
+import com.example.Triple_clone.dto.report.QReportResponseDto;
+import com.example.Triple_clone.dto.report.ReportSearchDto;
+import com.example.Triple_clone.dto.report.ReportResponseDto;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportAdminRepositoryImpl implements ReportAdminRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ReportResponseDto> searchReports(ReportSearchDto condition, Pageable pageable) {
+        QReport report = QReport.report;
+        QMember member = QMember.member;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (condition.getTargetType() != null) {
+            builder.and(report.targetType.eq(condition.getTargetType()));
+        }
+        if (condition.getStatus() != null) {
+            builder.and(report.status.eq(condition.getStatus()));
+        }
+        if (condition.getReason() != null) {
+            builder.and(report.reason.eq(condition.getReason()));
+        }
+        if (condition.getFromDate() != null) {
+            builder.and(report.createdAt.goe(condition.getFromDate()));
+        }
+        if (condition.getToDate() != null) {
+            builder.and(report.createdAt.loe(condition.getToDate()));
+        }
+
+        List<ReportResponseDto> results = queryFactory
+                .select(new QReportResponseDto(
+                        report.id,
+                        report.targetType,
+                        report.targetId,
+                        member.name,
+                        report.reason,
+                        report.status,
+                        report.createdAt
+                ))
+                .from(report)
+                .join(report.reporter, member)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(report.createdAt.desc())
+                .fetch();
+
+        long total = queryFactory
+                .select(report.count())
+                .from(report)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+}

--- a/src/main/java/com/example/Triple_clone/repository/ReportCountQueryRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/ReportCountQueryRepository.java
@@ -1,0 +1,10 @@
+package com.example.Triple_clone.repository;
+
+import com.example.Triple_clone.dto.report.ReportCountDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReportCountQueryRepository {
+    Page<ReportCountDto> searchReportCounts(String targetType, Long minReportCount, Pageable pageable);
+}
+

--- a/src/main/java/com/example/Triple_clone/repository/ReportCountQueryRepositoryImpl.java
+++ b/src/main/java/com/example/Triple_clone/repository/ReportCountQueryRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.example.Triple_clone.repository;
+
+import com.example.Triple_clone.domain.entity.QReportCount;
+import com.example.Triple_clone.dto.report.ReportCountDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportCountQueryRepositoryImpl implements ReportCountQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ReportCountDto> searchReportCounts(String targetType, Long minReportCount, Pageable pageable) {
+        QReportCount reportCount = QReportCount.reportCount;
+
+        JPAQuery<ReportCountDto> query = queryFactory
+                .select(Projections.constructor(
+                        ReportCountDto.class,
+                        reportCount.targetId,
+                        reportCount.targetType,
+                        reportCount.reportCount
+                ))
+                .from(reportCount)
+                .where(
+                        eqTargetType(targetType),
+                        goeMinReportCount(minReportCount)
+                );
+
+        List<ReportCountDto> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(reportCount.count())
+                .from(reportCount)
+                .where(
+                        eqTargetType(targetType),
+                        goeMinReportCount(minReportCount)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
+    private BooleanExpression eqTargetType(String targetType) {
+        return targetType != null ? QReportCount.reportCount.targetType.eq(targetType) : null;
+    }
+
+    private BooleanExpression goeMinReportCount(Long minReportCount) {
+        return minReportCount != null ? QReportCount.reportCount.count.goe(minReportCount) : null;
+    }
+}
+
+

--- a/src/main/java/com/example/Triple_clone/repository/ReportCountRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/ReportCountRepository.java
@@ -1,0 +1,10 @@
+package com.example.Triple_clone.repository;
+
+import com.example.Triple_clone.domain.entity.ReportCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportCountRepository extends JpaRepository<ReportCount, Long> {
+    Optional<ReportCount> findByTargetIdAndTargetType(Long targetId, String targetType);
+}

--- a/src/main/java/com/example/Triple_clone/service/report/ReportAdminService.java
+++ b/src/main/java/com/example/Triple_clone/service/report/ReportAdminService.java
@@ -1,9 +1,13 @@
 package com.example.Triple_clone.service.report;
 
 import com.example.Triple_clone.domain.entity.Report;
+import com.example.Triple_clone.domain.entity.ReportCount;
+import com.example.Triple_clone.dto.report.ReportCountDto;
 import com.example.Triple_clone.dto.report.ReportResponseDto;
 import com.example.Triple_clone.dto.report.ReportSearchDto;
 import com.example.Triple_clone.repository.ReportAdminRepository;
+import com.example.Triple_clone.repository.ReportCountQueryRepository;
+import com.example.Triple_clone.repository.ReportCountRepository;
 import com.example.Triple_clone.repository.ReportRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -11,15 +15,40 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ReportAdminService {
     private final ReportAdminRepository reportAdminRepository;
     private final ReportRepository reportRepository;
+    private final ReportCountQueryRepository reportCountQueryRepository;
+    private final ReportCountRepository reportCountRepository;
 
     public Page<ReportResponseDto> getReports(ReportSearchDto condition, Pageable pageable) {
         return reportAdminRepository.searchReports(condition, pageable);
     }
+
+    public List<ReportCountDto> getReportCounts(Pageable pageable) {
+        Page<ReportCount> reportCounts = reportCountRepository.findAll(pageable);
+
+        return reportCounts.stream()
+                .map(reportCount -> new ReportCountDto(reportCount.getTargetId(), reportCount.getTargetType(), reportCount.getCount()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ReportCountDto> getReportCountsByCondition(String targetType, Long minReportCount, Pageable pageable) {
+        Page<ReportCountDto> reportCounts = reportCountQueryRepository.searchReportCounts(targetType, minReportCount, pageable);
+
+        return reportCounts.stream()
+                .collect(Collectors.toList());
+    }
+
+    public Page<ReportResponseDto> getReportsByTarget(String targetType, Long targetId, Pageable pageable) {
+        return reportAdminRepository.searchReportsByTarget(targetType, targetId, pageable);
+    }
+
 
     public void approveReport(Long reportId) {
         Report report = reportRepository.findById(reportId)

--- a/src/main/java/com/example/Triple_clone/service/report/ReportAdminService.java
+++ b/src/main/java/com/example/Triple_clone/service/report/ReportAdminService.java
@@ -1,0 +1,37 @@
+package com.example.Triple_clone.service.report;
+
+import com.example.Triple_clone.domain.entity.Report;
+import com.example.Triple_clone.dto.report.ReportResponseDto;
+import com.example.Triple_clone.dto.report.ReportSearchDto;
+import com.example.Triple_clone.repository.ReportAdminRepository;
+import com.example.Triple_clone.repository.ReportRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportAdminService {
+    private final ReportAdminRepository reportAdminRepository;
+    private final ReportRepository reportRepository;
+
+    public Page<ReportResponseDto> getReports(ReportSearchDto condition, Pageable pageable) {
+        return reportAdminRepository.searchReports(condition, pageable);
+    }
+
+    public void approveReport(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new EntityNotFoundException("신고를 찾을 수 없습니다."));
+
+        report.approve();
+    }
+
+    public void rejectReport(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new EntityNotFoundException("신고를 찾을 수 없습니다."));
+
+        report.reject();
+    }
+}

--- a/src/main/java/com/example/Triple_clone/service/report/ReportService.java
+++ b/src/main/java/com/example/Triple_clone/service/report/ReportService.java
@@ -1,10 +1,12 @@
 package com.example.Triple_clone.service.report;
 
 import com.example.Triple_clone.domain.entity.Member;
-import com.example.Triple_clone.domain.entity.Review;
 import com.example.Triple_clone.domain.entity.Report;
+import com.example.Triple_clone.domain.entity.ReportCount;
+import com.example.Triple_clone.domain.entity.Review;
 import com.example.Triple_clone.domain.vo.ReportingReason;
 import com.example.Triple_clone.repository.MemberRepository;
+import com.example.Triple_clone.repository.ReportCountRepository;
 import com.example.Triple_clone.repository.ReportRepository;
 import com.example.Triple_clone.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ public class ReportService {
     private final ReportRepository reportRepository;
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
+    private final ReportCountRepository reportCountRepository;
 
     public void reportReview(Long reviewId, Long reporterId, ReportingReason reason, String detail) {
         Review review = reviewRepository.findById(reviewId)
@@ -31,5 +34,12 @@ public class ReportService {
 
         Report report = Report.of(review, reporter, reason, detail);
         reportRepository.save(report);
+
+        ReportCount reportCount = reportCountRepository.findByTargetIdAndTargetType(
+                        report.getTargetId(), report.getTargetType())
+                .orElse(new ReportCount(report.getTargetId(), report.getTargetType(), 0L));
+
+        reportCount.incrementCount();
+        reportCountRepository.save(reportCount);
     }
 }

--- a/src/main/java/com/example/Triple_clone/web/controller/report/ReportAdminController.java
+++ b/src/main/java/com/example/Triple_clone/web/controller/report/ReportAdminController.java
@@ -1,5 +1,6 @@
 package com.example.Triple_clone.web.controller.report;
 
+import com.example.Triple_clone.dto.report.ReportCountDto;
 import com.example.Triple_clone.dto.report.ReportResponseDto;
 import com.example.Triple_clone.dto.report.ReportSearchDto;
 import com.example.Triple_clone.service.report.ReportAdminService;
@@ -9,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +24,31 @@ public class ReportAdminController {
             ReportSearchDto condition,
             @PageableDefault(size = 10) Pageable pageable) {
         return reportService.getReports(condition, pageable);
+    }
+
+    @GetMapping("/report-counts")
+    public List<ReportCountDto> getReportCountsByCondition(
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return reportService.getReportCounts(pageable);
+    }
+
+    @GetMapping("/report-counts/conditions")
+    public List<ReportCountDto> getReportCountsByCondition(
+            @RequestParam(required = false) String targetType,
+            @RequestParam(required = false) Long minReportCount,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return reportService.getReportCountsByCondition(targetType, minReportCount, pageable);
+    }
+
+    @GetMapping("/reports/by-target")
+    public Page<ReportResponseDto> getReportsByTarget(
+            @RequestParam String targetType,
+            @RequestParam Long targetId,
+            Pageable pageable
+    ) {
+        return reportService.getReportsByTarget(targetType, targetId, pageable);
     }
 
     @PostMapping("/{reportId}/approve")

--- a/src/main/java/com/example/Triple_clone/web/controller/report/ReportAdminController.java
+++ b/src/main/java/com/example/Triple_clone/web/controller/report/ReportAdminController.java
@@ -1,0 +1,37 @@
+package com.example.Triple_clone.web.controller.report;
+
+import com.example.Triple_clone.dto.report.ReportResponseDto;
+import com.example.Triple_clone.dto.report.ReportSearchDto;
+import com.example.Triple_clone.service.report.ReportAdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/reports")
+public class ReportAdminController {
+    private final ReportAdminService reportService;
+
+    @GetMapping
+    public Page<ReportResponseDto> searchReports(
+            ReportSearchDto condition,
+            @PageableDefault(size = 10) Pageable pageable) {
+        return reportService.getReports(condition, pageable);
+    }
+
+    @PostMapping("/{reportId}/approve")
+    public ResponseEntity<Void> approveReport(@PathVariable Long reportId) {
+        reportService.approveReport(reportId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{reportId}/reject")
+    public ResponseEntity<Void> rejectReport(@PathVariable Long reportId) {
+        reportService.rejectReport(reportId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/test/java/com/example/Triple_clone/domain/dto/ReportRequestDtoTest.java
+++ b/src/test/java/com/example/Triple_clone/domain/dto/ReportRequestDtoTest.java
@@ -1,6 +1,7 @@
-package com.example.Triple_clone.dto.report;
+package com.example.Triple_clone.domain.dto;
 
 import com.example.Triple_clone.domain.vo.ReportingReason;
+import com.example.Triple_clone.dto.report.ReportRequestDto;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/example/Triple_clone/domain/entity/ReportCountTest.java
+++ b/src/test/java/com/example/Triple_clone/domain/entity/ReportCountTest.java
@@ -1,0 +1,37 @@
+package com.example.Triple_clone.domain.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReportCountTest {
+
+    @Test
+    @DisplayName("ReportCount 객체가 빌더로 정상 생성되어야 한다")
+    void buildReportCount() {
+        ReportCount reportCount = ReportCount.builder()
+                .targetId(1L)
+                .targetType("REVIEW")
+                .count(3L)
+                .build();
+
+        assertThat(reportCount.getTargetId()).isEqualTo(1L);
+        assertThat(reportCount.getTargetType()).isEqualTo("REVIEW");
+        assertThat(reportCount.getCount()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("신고 카운트가 1 증가되어야 한다")
+    void incrementReportCount() {
+        ReportCount reportCount = ReportCount.builder()
+                .targetId(2L)
+                .targetType("COMMENT")
+                .count(5L)
+                .build();
+
+        reportCount.incrementCount();
+
+        assertThat(reportCount.getCount()).isEqualTo(6L);
+    }
+}

--- a/src/test/java/com/example/Triple_clone/service/report/ReportAdminServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/report/ReportAdminServiceTest.java
@@ -1,0 +1,114 @@
+package com.example.Triple_clone.service.report;
+
+import com.example.Triple_clone.domain.entity.Report;
+import com.example.Triple_clone.domain.entity.ReportCount;
+import com.example.Triple_clone.dto.report.ReportCountDto;
+import com.example.Triple_clone.dto.report.ReportResponseDto;
+import com.example.Triple_clone.dto.report.ReportSearchDto;
+import com.example.Triple_clone.repository.ReportAdminRepository;
+import com.example.Triple_clone.repository.ReportCountQueryRepository;
+import com.example.Triple_clone.repository.ReportCountRepository;
+import com.example.Triple_clone.repository.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class ReportAdminServiceTest {
+
+    @InjectMocks
+    private ReportAdminService reportAdminService;
+
+    @Mock private ReportAdminRepository reportAdminRepository;
+    @Mock private ReportRepository reportRepository;
+    @Mock private ReportCountRepository reportCountRepository;
+    @Mock private ReportCountQueryRepository reportCountQueryRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("신고 승인 처리 성공")
+    void approveReport_success() {
+        Report report = mock(Report.class);
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(report));
+
+        reportAdminService.approveReport(1L);
+
+        verify(report).approve();
+    }
+
+    @Test
+    @DisplayName("신고 거절 처리 성공")
+    void rejectReport_success() {
+        Report report = mock(Report.class);
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(report));
+
+        reportAdminService.rejectReport(1L);
+
+        verify(report).reject();
+    }
+
+    @Test
+    @DisplayName("신고 목록 조회 성공")
+    void getReports_success() {
+        ReportSearchDto condition = new ReportSearchDto();
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ReportResponseDto> page = new PageImpl<>(List.of(mock(ReportResponseDto.class)));
+
+        when(reportAdminRepository.searchReports(condition, pageable)).thenReturn(page);
+
+        Page<ReportResponseDto> result = reportAdminService.getReports(condition, pageable);
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("신고 누적 목록 조회 성공")
+    void getReportCounts_success() {
+        Pageable pageable = PageRequest.of(0, 10);
+        ReportCount entity = ReportCount.builder().targetId(1L).targetType("REVIEW").count(5L).build();
+        when(reportCountRepository.findAll(pageable)).thenReturn(new PageImpl<>(List.of(entity)));
+
+        List<ReportCountDto> result = reportAdminService.getReportCounts(pageable);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTargetId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("신고 누적 조건별 조회 성공")
+    void getReportCountsByCondition_success() {
+        Pageable pageable = PageRequest.of(0, 10);
+        ReportCountDto dto = new ReportCountDto(1L, "REVIEW", 10L);
+
+        when(reportCountQueryRepository.searchReportCounts("REVIEW", 5L, pageable))
+                .thenReturn(new PageImpl<>(List.of(dto)));
+
+        List<ReportCountDto> result = reportAdminService.getReportCountsByCondition("REVIEW", 5L, pageable);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTargetType()).isEqualTo("REVIEW");
+    }
+
+    @Test
+    @DisplayName("특정 대상의 신고 조회 성공")
+    void getReportsByTarget_success() {
+        Pageable pageable = PageRequest.of(0, 10);
+        when(reportAdminRepository.searchReportsByTarget("REVIEW", 1L, pageable))
+                .thenReturn(new PageImpl<>(List.of(mock(ReportResponseDto.class))));
+
+        Page<ReportResponseDto> result = reportAdminService.getReportsByTarget("REVIEW", 1L, pageable);
+
+        assertThat(result).hasSize(1);
+    }
+}

--- a/src/test/java/com/example/Triple_clone/service/report/ReportServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/report/ReportServiceTest.java
@@ -4,6 +4,7 @@ import com.example.Triple_clone.domain.entity.Member;
 import com.example.Triple_clone.domain.entity.Review;
 import com.example.Triple_clone.domain.vo.ReportingReason;
 import com.example.Triple_clone.repository.MemberRepository;
+import com.example.Triple_clone.repository.ReportCountRepository;
 import com.example.Triple_clone.repository.ReportRepository;
 import com.example.Triple_clone.repository.ReviewRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +27,9 @@ public class ReportServiceTest {
 
     @Mock
     private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReportCountRepository reportCountRepository;
 
     @InjectMocks
     private ReportService reportService;


### PR DESCRIPTION
## 관리자가 신고 목록을 조회하고, 신고를 승인/거절하며, 신고 카운트를 확인할 수 있는 기능을 추가했습니다.

### 변경사항
- 신고 목록 조회: 페이징 및 조건 필터링 적용

- 신고 카운트 조회: 신고 대상 별 카운트 확인, 필터링

- 특정 요소 신고 리스트: targetId, targetType으로 신고 목록 조회

- 신고 승인/거절: 신고에 대한 승인 및 거절 처리 기능 추가


#### Querydsl을 사용하여 동적 조회가 가능하도록 설정함
#### 모든 조회의 page 크기는 10으로 고정함
#### 테스트 코드 수정 중 리뷰에 대한 테스트 코드 오류로 수정 및 추가 부분 있음

<hr>

**ReportCount Entity와 ReportCountDto의 targetType 필드는 해당 PR에는 String 타입으로 있습니다,**
**#65 PR의 코드 리뷰 개선 과정에서 enum타입의 ReportTargetType로 변경하였습니다**



## ISSUE
https://github.com/piedra-de-flor/nomadic/issues/66
https://github.com/piedra-de-flor/nomadic/issues/67
https://github.com/piedra-de-flor/nomadic/issues/68