### PR TITLE
알림 히스토리 기록 기능 구현 PR

### DIFF
--- a/src/main/java/com/example/Triple_clone/domain/entity/Notification.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/Notification.java
@@ -4,6 +4,7 @@ import com.example.Triple_clone.domain.vo.NotificationTarget;
 import com.example.Triple_clone.domain.vo.NotificationType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,6 +37,15 @@ public class Notification {
     @PrePersist
     public void prePersist() {
         this.sentAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Notification(NotificationType type, NotificationTarget target, String title, String content, Long targetUserId) {
+        this.type = type;
+        this.target = target;
+        this.title = title;
+        this.content = content;
+        this.targetUserId = targetUserId;
     }
 }
 

--- a/src/main/java/com/example/Triple_clone/domain/entity/Notification.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/Notification.java
@@ -1,0 +1,41 @@
+package com.example.Triple_clone.domain.entity;
+
+import com.example.Triple_clone.domain.vo.NotificationTarget;
+import com.example.Triple_clone.domain.vo.NotificationType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationTarget target;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    private String content;
+
+    private LocalDateTime sentAt;
+
+    private Long targetUserId;
+
+    @PrePersist
+    public void prePersist() {
+        this.sentAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/example/Triple_clone/domain/entity/NotificationStatus.java
+++ b/src/main/java/com/example/Triple_clone/domain/entity/NotificationStatus.java
@@ -1,0 +1,38 @@
+package com.example.Triple_clone.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationStatus {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Notification notification;
+
+    private Long userId;
+
+    private boolean isRead = false;
+
+    private LocalDateTime readAt;
+
+    @Builder
+    public NotificationStatus(Notification notification, Long userId) {
+        this.notification = notification;
+        this.userId = userId;
+    }
+
+    public void read() {
+        this.isRead = true;
+        this.readAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/Triple_clone/domain/vo/NotificationTarget.java
+++ b/src/main/java/com/example/Triple_clone/domain/vo/NotificationTarget.java
@@ -1,0 +1,7 @@
+package com.example.Triple_clone.domain.vo;
+
+public enum NotificationTarget {
+    GLOBAL,
+    PERSONAL,
+    ADMIN
+}

--- a/src/main/java/com/example/Triple_clone/dto/notification/NotificationDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/notification/NotificationDto.java
@@ -1,8 +1,10 @@
 package com.example.Triple_clone.dto.notification;
 
+import com.example.Triple_clone.domain.vo.NotificationTarget;
 import com.example.Triple_clone.domain.vo.NotificationType;
 
 public record NotificationDto(
     NotificationType type,
+    NotificationTarget target,
     Object payload
 ) {}

--- a/src/main/java/com/example/Triple_clone/dto/notification/NotificationSaveRequest.java
+++ b/src/main/java/com/example/Triple_clone/dto/notification/NotificationSaveRequest.java
@@ -1,0 +1,14 @@
+package com.example.Triple_clone.dto.notification;
+
+import com.example.Triple_clone.domain.vo.NotificationTarget;
+import com.example.Triple_clone.domain.vo.NotificationType;
+
+import java.util.List;
+
+public record NotificationSaveRequest(
+        NotificationType type,
+        NotificationTarget target,
+        String title,
+        String content,
+        List<Long> targetUserIds
+) {}

--- a/src/main/java/com/example/Triple_clone/dto/notification/NotificationSearchDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/notification/NotificationSearchDto.java
@@ -1,0 +1,11 @@
+package com.example.Triple_clone.dto.notification;
+
+import java.time.LocalDateTime;
+
+public record NotificationSearchDto(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime sentAt,
+        boolean isRead
+) {}

--- a/src/main/java/com/example/Triple_clone/dto/notification/NotificationSearchDto.java
+++ b/src/main/java/com/example/Triple_clone/dto/notification/NotificationSearchDto.java
@@ -1,5 +1,7 @@
 package com.example.Triple_clone.dto.notification;
 
+import com.example.Triple_clone.domain.entity.Notification;
+
 import java.time.LocalDateTime;
 
 public record NotificationSearchDto(
@@ -8,4 +10,14 @@ public record NotificationSearchDto(
         String content,
         LocalDateTime sentAt,
         boolean isRead
-) {}
+) {
+    public static NotificationSearchDto from(Notification notification, boolean isRead) {
+        return new NotificationSearchDto(
+                notification.getId(),
+                notification.getTitle(),
+                notification.getContent(),
+                notification.getSentAt(),
+                isRead
+        );
+    }
+}

--- a/src/main/java/com/example/Triple_clone/dto/notification/NotificationSentEvent.java
+++ b/src/main/java/com/example/Triple_clone/dto/notification/NotificationSentEvent.java
@@ -1,0 +1,3 @@
+package com.example.Triple_clone.dto.notification;
+
+public record NotificationSentEvent(Long notificationId, Long memberId) {}

--- a/src/main/java/com/example/Triple_clone/repository/MemberRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/MemberRepository.java
@@ -3,8 +3,10 @@ package com.example.Triple_clone.repository;
 import com.example.Triple_clone.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    List<Member> findAllByRolesEquals(List<String> role);
 }

--- a/src/main/java/com/example/Triple_clone/repository/NotificationRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package com.example.Triple_clone.repository;
+
+import com.example.Triple_clone.domain.entity.Notification;
+import com.example.Triple_clone.domain.vo.NotificationTarget;
+import com.example.Triple_clone.domain.vo.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByType(NotificationType type);
+    List<Notification> findByTarget(NotificationTarget type);
+    List<Notification> findByTargetUserId(Long userId);
+}

--- a/src/main/java/com/example/Triple_clone/repository/NotificationStatusRepository.java
+++ b/src/main/java/com/example/Triple_clone/repository/NotificationStatusRepository.java
@@ -1,0 +1,13 @@
+package com.example.Triple_clone.repository;
+
+import com.example.Triple_clone.domain.entity.Notification;
+import com.example.Triple_clone.domain.entity.NotificationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationStatusRepository extends JpaRepository<NotificationStatus, Long> {
+    Optional<NotificationStatus> findByUserIdAndNotification(Long userId, Notification notification);
+    List<NotificationStatus> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationEventService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationEventService.java
@@ -15,7 +15,7 @@ public class NotificationEventService {
     public void notify(NotificationDto event) {
         for (NotificationSender sender : senders) {
             if (sender.supports(event.type())) {
-                sender.send(event);
+                sender.process(event);
             }
         }
     }

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationEventService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationEventService.java
@@ -1,0 +1,23 @@
+package com.example.Triple_clone.service.notification;
+
+import com.example.Triple_clone.dto.notification.NotificationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationEventService {
+
+    private final List<NotificationSender> senders;
+
+    public void notify(NotificationDto event) {
+        for (NotificationSender sender : senders) {
+            if (sender.supports(event.type())) {
+                sender.send(event);
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationSaveService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationSaveService.java
@@ -1,38 +1,54 @@
 package com.example.Triple_clone.service.notification;
 
+import com.example.Triple_clone.domain.entity.Member;
 import com.example.Triple_clone.domain.entity.Notification;
-import com.example.Triple_clone.domain.entity.NotificationStatus;
+import com.example.Triple_clone.domain.vo.NotificationTarget;
 import com.example.Triple_clone.dto.notification.NotificationSaveRequest;
+import com.example.Triple_clone.dto.notification.NotificationSentEvent;
+import com.example.Triple_clone.repository.MemberRepository;
 import com.example.Triple_clone.repository.NotificationRepository;
-import com.example.Triple_clone.repository.NotificationStatusRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationSaveService {
-
     private final NotificationRepository notificationRepository;
-    private final NotificationStatusRepository notificationStatusRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationStatusQueue queue;
 
     public void save(NotificationSaveRequest request) {
-        for (Long userId : request.targetUserIds()) {
+        if (request.target() == NotificationTarget.GLOBAL) {
+            List<String> userRole = List.of("USER");
+            List<Member> allMembers = memberRepository.findAllByRolesEquals(userRole);
+
             Notification notification = Notification.builder()
                     .type(request.type())
                     .target(request.target())
                     .title(request.title())
                     .content(request.content())
-                    .targetUserId(userId)
+                    .targetUserId(null)
                     .build();
-
             notificationRepository.save(notification);
 
-            NotificationStatus status = NotificationStatus.builder()
-                    .notification(notification)
-                    .userId(userId)
-                    .build();
+            for (Member member : allMembers) {
+                queue.enqueue(new NotificationSentEvent(notification.getId(), member.getId()));
+            }
+        } else {
+            for (Long memberId : request.targetUserIds()) {
+                Notification notification = Notification.builder()
+                        .type(request.type())
+                        .target(request.target())
+                        .title(request.title())
+                        .content(request.content())
+                        .targetUserId(memberId)
+                        .build();
+                notificationRepository.save(notification);
 
-            notificationStatusRepository.save(status);
+                queue.enqueue(new NotificationSentEvent(notification.getId(), memberId));
+            }
         }
     }
 }

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationSaveService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationSaveService.java
@@ -2,52 +2,37 @@ package com.example.Triple_clone.service.notification;
 
 import com.example.Triple_clone.domain.entity.Notification;
 import com.example.Triple_clone.domain.entity.NotificationStatus;
-import com.example.Triple_clone.domain.vo.NotificationTarget;
-import com.example.Triple_clone.domain.vo.NotificationType;
+import com.example.Triple_clone.dto.notification.NotificationSaveRequest;
 import com.example.Triple_clone.repository.NotificationRepository;
 import com.example.Triple_clone.repository.NotificationStatusRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationSaveService {
+
     private final NotificationRepository notificationRepository;
     private final NotificationStatusRepository notificationStatusRepository;
 
-    private void createNotification(NotificationType type, NotificationTarget target, Long targetUserId, String title, String content) {
-        Notification notification = Notification.builder()
-                .type(type)
-                .target(target)
-                .title(title)
-                .content(content)
-                .targetUserId(targetUserId)
-                .build();
+    public void save(NotificationSaveRequest request) {
+        for (Long userId : request.targetUserIds()) {
+            Notification notification = Notification.builder()
+                    .type(request.type())
+                    .target(request.target())
+                    .title(request.title())
+                    .content(request.content())
+                    .targetUserId(userId)
+                    .build();
 
-        notificationRepository.save(notification);
+            notificationRepository.save(notification);
 
-        NotificationStatus status = NotificationStatus.builder()
-                .notification(notification)
-                .userId(targetUserId)
-                .build();
+            NotificationStatus status = NotificationStatus.builder()
+                    .notification(notification)
+                    .userId(userId)
+                    .build();
 
-        notificationStatusRepository.save(status);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createGlobalNotification(NotificationType type, String title, String content) {
-        createNotification(type, NotificationTarget.GLOBAL, null, title, content);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createPersonalNotification(NotificationType type, Long targetUserId, String title, String content) {
-        createNotification(type, NotificationTarget.PERSONAL, targetUserId, title, content);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createAdminNotification(NotificationType type, Long targetUserId, String title, String content) {
-        createNotification(type, NotificationTarget.ADMIN, targetUserId, title, content);
+            notificationStatusRepository.save(status);
+        }
     }
 }

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationSaveService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationSaveService.java
@@ -1,0 +1,53 @@
+package com.example.Triple_clone.service.notification;
+
+import com.example.Triple_clone.domain.entity.Notification;
+import com.example.Triple_clone.domain.entity.NotificationStatus;
+import com.example.Triple_clone.domain.vo.NotificationTarget;
+import com.example.Triple_clone.domain.vo.NotificationType;
+import com.example.Triple_clone.repository.NotificationRepository;
+import com.example.Triple_clone.repository.NotificationStatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSaveService {
+    private final NotificationRepository notificationRepository;
+    private final NotificationStatusRepository notificationStatusRepository;
+
+    private void createNotification(NotificationType type, NotificationTarget target, Long targetUserId, String title, String content) {
+        Notification notification = Notification.builder()
+                .type(type)
+                .target(target)
+                .title(title)
+                .content(content)
+                .targetUserId(targetUserId)
+                .build();
+
+        notificationRepository.save(notification);
+
+        NotificationStatus status = NotificationStatus.builder()
+                .notification(notification)
+                .userId(targetUserId)
+                .build();
+
+        notificationStatusRepository.save(status);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createGlobalNotification(NotificationType type, String title, String content) {
+        createNotification(type, NotificationTarget.GLOBAL, null, title, content);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createPersonalNotification(NotificationType type, Long targetUserId, String title, String content) {
+        createNotification(type, NotificationTarget.PERSONAL, targetUserId, title, content);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createAdminNotification(NotificationType type, Long targetUserId, String title, String content) {
+        createNotification(type, NotificationTarget.ADMIN, targetUserId, title, content);
+    }
+}

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationSender.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationSender.java
@@ -1,8 +1,9 @@
 package com.example.Triple_clone.service.notification;
 
+import com.example.Triple_clone.dto.notification.NotificationDto;
 import com.example.Triple_clone.domain.vo.NotificationChannelType;
 import com.example.Triple_clone.domain.vo.NotificationType;
-import com.example.Triple_clone.dto.notification.NotificationDto;
+import com.example.Triple_clone.dto.notification.NotificationSaveRequest;
 import com.example.Triple_clone.service.notification.channel.ChannelNotificationSender;
 import com.example.Triple_clone.web.support.HtmlTemplateRenderer;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +14,18 @@ import java.util.List;
 public abstract class NotificationSender {
     protected final HtmlTemplateRenderer htmlTemplateRenderer;
     protected final List<ChannelNotificationSender> channelSenders;
+    protected final NotificationSaveService notificationSaveService;
 
-    abstract boolean supports(NotificationType type);
+    public final void process(NotificationDto dto) {
+        NotificationSaveRequest saveRequest = prepareAndSend(dto);
+        notificationSaveService.save(saveRequest);
+    }
 
-    abstract void send(NotificationDto event);
+    protected abstract NotificationSaveRequest prepareAndSend(NotificationDto dto);
 
-    public NotificationChannelType resolveChannelType(ChannelNotificationSender sender) {
+    public abstract boolean supports(NotificationType type);
+
+    protected NotificationChannelType resolveChannelType(ChannelNotificationSender sender) {
         return sender.getChannelType();
     }
 }
-

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
@@ -1,25 +1,27 @@
 package com.example.Triple_clone.service.notification;
 
 import com.example.Triple_clone.domain.entity.Notification;
+import com.example.Triple_clone.domain.entity.NotificationStatus;
 import com.example.Triple_clone.domain.vo.NotificationTarget;
 import com.example.Triple_clone.dto.notification.NotificationSearchDto;
 import com.example.Triple_clone.repository.NotificationRepository;
+import com.example.Triple_clone.repository.NotificationStatusRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
-
     private final NotificationRepository notificationRepository;
+    private final NotificationStatusRepository statusRepository;
 
-    /**
-     * 유저에게 보여줄 알림 목록 (전체 + 개인)
-     */
+    @Transactional
     public List<NotificationSearchDto> getUserNotifications(Long userId) {
         List<Notification> globalNotifications = notificationRepository.findByTarget(NotificationTarget.GLOBAL);
         List<Notification> personalNotifications = notificationRepository.findByTargetUserId(userId);
@@ -27,6 +29,29 @@ public class NotificationService {
         List<Notification> all = new ArrayList<>();
         all.addAll(globalNotifications);
         all.addAll(personalNotifications);
+
+        return all.stream()
+                .map(notification -> {
+                    boolean isRead = statusRepository.findByUserIdAndNotification(userId, notification)
+                            .map(NotificationStatus::isRead)
+                            .orElse(false);
+
+                    return NotificationSearchDto.from(notification, isRead);
+                })
+                .sorted(Comparator.comparing(NotificationSearchDto::sentAt).reversed())
+                .toList();
+    }
+
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new IllegalArgumentException("알림 없음"));
+
+        NotificationStatus status = statusRepository
+                .findByUserIdAndNotification(userId, notification)
+                .orElseThrow(() -> new NoSuchElementException("상태값 없음"));
+
+        status.read();
     }
 
     /**

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
@@ -1,11 +1,14 @@
 package com.example.Triple_clone.service.notification;
 
+import com.example.Triple_clone.domain.entity.Member;
 import com.example.Triple_clone.domain.entity.Notification;
 import com.example.Triple_clone.domain.entity.NotificationStatus;
 import com.example.Triple_clone.domain.vo.NotificationTarget;
 import com.example.Triple_clone.dto.notification.NotificationSearchDto;
+import com.example.Triple_clone.repository.MemberRepository;
 import com.example.Triple_clone.repository.NotificationRepository;
 import com.example.Triple_clone.repository.NotificationStatusRepository;
+import com.example.Triple_clone.service.membership.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,11 +23,13 @@ import java.util.NoSuchElementException;
 public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final NotificationStatusRepository statusRepository;
+    private final UserService userService;
 
     @Transactional
-    public List<NotificationSearchDto> getUserNotifications(Long userId) {
+    public List<NotificationSearchDto> getUserNotifications(String email) {
+        Member member = userService.findByEmail(email);
         List<Notification> globalNotifications = notificationRepository.findByTarget(NotificationTarget.GLOBAL);
-        List<Notification> personalNotifications = notificationRepository.findByTargetUserId(userId);
+        List<Notification> personalNotifications = notificationRepository.findByTargetUserId(member.getId());
 
         List<Notification> all = new ArrayList<>();
         all.addAll(globalNotifications);
@@ -32,7 +37,7 @@ public class NotificationService {
 
         return all.stream()
                 .map(notification -> {
-                    boolean isRead = statusRepository.findByUserIdAndNotification(userId, notification)
+                    boolean isRead = statusRepository.findByUserIdAndNotification(member.getId(), notification)
                             .map(NotificationStatus::isRead)
                             .orElse(false);
 
@@ -43,12 +48,13 @@ public class NotificationService {
     }
 
     @Transactional
-    public void markAsRead(Long userId, Long notificationId) {
+    public void markAsRead(String email, Long notificationId) {
+        Member member = userService.findByEmail(email);
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new IllegalArgumentException("알림 없음"));
 
         NotificationStatus status = statusRepository
-                .findByUserIdAndNotification(userId, notification)
+                .findByUserIdAndNotification(member.getId(), notification)
                 .orElseThrow(() -> new NoSuchElementException("상태값 없음"));
 
         status.read();

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
@@ -54,7 +54,11 @@ public class NotificationService {
 
         NotificationStatus status = statusRepository
                 .findByUserIdAndNotification(member.getId(), notification)
-                .orElseThrow(() -> new NoSuchElementException("상태값 없음"));
+                .orElseGet(() -> NotificationStatus
+                        .builder()
+                        .notification(notification)
+                        .userId(member.getId())
+                        .build());
 
         status.read();
     }

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
@@ -5,7 +5,6 @@ import com.example.Triple_clone.domain.entity.Notification;
 import com.example.Triple_clone.domain.entity.NotificationStatus;
 import com.example.Triple_clone.domain.vo.NotificationTarget;
 import com.example.Triple_clone.dto.notification.NotificationSearchDto;
-import com.example.Triple_clone.repository.MemberRepository;
 import com.example.Triple_clone.repository.NotificationRepository;
 import com.example.Triple_clone.repository.NotificationStatusRepository;
 import com.example.Triple_clone.service.membership.UserService;
@@ -58,18 +57,6 @@ public class NotificationService {
                 .orElseThrow(() -> new NoSuchElementException("상태값 없음"));
 
         status.read();
-    }
-
-    /**
-     * 전체 알림 생성
-     */
-    public void createGlobalNotification(String title, String content) {
-    }
-
-    /**
-     * 개인 알림 생성
-     */
-    public void createPersonalNotification(Long targetUserId, String title, String content) {
     }
 }
 

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationService.java
@@ -1,23 +1,44 @@
 package com.example.Triple_clone.service.notification;
 
-import com.example.Triple_clone.dto.notification.NotificationDto;
+import com.example.Triple_clone.domain.entity.Notification;
+import com.example.Triple_clone.domain.vo.NotificationTarget;
+import com.example.Triple_clone.dto.notification.NotificationSearchDto;
+import com.example.Triple_clone.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
-    private final List<NotificationSender> senders;
+    private final NotificationRepository notificationRepository;
 
-    public void notify(NotificationDto event) {
-        for (NotificationSender sender : senders) {
-            if (sender.supports(event.type())) {
-                sender.send(event);
-            }
-        }
+    /**
+     * 유저에게 보여줄 알림 목록 (전체 + 개인)
+     */
+    public List<NotificationSearchDto> getUserNotifications(Long userId) {
+        List<Notification> globalNotifications = notificationRepository.findByTarget(NotificationTarget.GLOBAL);
+        List<Notification> personalNotifications = notificationRepository.findByTargetUserId(userId);
+
+        List<Notification> all = new ArrayList<>();
+        all.addAll(globalNotifications);
+        all.addAll(personalNotifications);
+    }
+
+    /**
+     * 전체 알림 생성
+     */
+    public void createGlobalNotification(String title, String content) {
+    }
+
+    /**
+     * 개인 알림 생성
+     */
+    public void createPersonalNotification(Long targetUserId, String title, String content) {
     }
 }
 

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationStatusBatchProcessor.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationStatusBatchProcessor.java
@@ -18,7 +18,7 @@ public class NotificationStatusBatchProcessor {
     private final NotificationRepository notificationRepository;
     private final NotificationStatusRepository statusRepository;
 
-    @Scheduled(fixedDelay = 5000)
+    @Scheduled(cron = "0 0 0 * * *")
     public void process() {
         List<NotificationSentEvent> events = queue.drainAll();
         for (NotificationSentEvent event : events) {

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationStatusBatchProcessor.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationStatusBatchProcessor.java
@@ -1,0 +1,35 @@
+package com.example.Triple_clone.service.notification;
+
+import com.example.Triple_clone.domain.entity.NotificationStatus;
+import com.example.Triple_clone.dto.notification.NotificationSentEvent;
+import com.example.Triple_clone.repository.NotificationRepository;
+import com.example.Triple_clone.repository.NotificationStatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationStatusBatchProcessor {
+
+    private final NotificationStatusQueue queue;
+    private final NotificationRepository notificationRepository;
+    private final NotificationStatusRepository statusRepository;
+
+    @Scheduled(fixedDelay = 5000)
+    public void process() {
+        List<NotificationSentEvent> events = queue.drainAll();
+        for (NotificationSentEvent event : events) {
+            notificationRepository.findById(event.notificationId())
+                    .ifPresent(notification -> {
+                        NotificationStatus status = NotificationStatus.builder()
+                                .notification(notification)
+                                .userId(event.memberId())
+                                .build();
+                        statusRepository.save(status);
+                    });
+        }
+    }
+}

--- a/src/main/java/com/example/Triple_clone/service/notification/NotificationStatusQueue.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/NotificationStatusQueue.java
@@ -1,0 +1,28 @@
+package com.example.Triple_clone.service.notification;
+
+import com.example.Triple_clone.dto.notification.NotificationSentEvent;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Component
+public class NotificationStatusQueue {
+    private final Queue<NotificationSentEvent> queue = new ConcurrentLinkedQueue<>();
+
+    public void enqueue(NotificationSentEvent event) {
+        queue.add(event);
+    }
+
+    public List<NotificationSentEvent> drainAll() {
+        List<NotificationSentEvent> drained = new ArrayList<>();
+        NotificationSentEvent event;
+        while ((event = queue.poll()) != null) {
+            drained.add(event);
+        }
+        return drained;
+    }
+}
+

--- a/src/main/java/com/example/Triple_clone/service/notification/channel/ChannelNotificationSender.java
+++ b/src/main/java/com/example/Triple_clone/service/notification/channel/ChannelNotificationSender.java
@@ -10,6 +10,6 @@ public interface ChannelNotificationSender {
     void send(NotificationMessage message);
     NotificationChannelType getChannelType();
 
-    public MimeMessage makeMessage(NotificationMessage message) throws MessagingException;
+    MimeMessage makeMessage(NotificationMessage message) throws MessagingException;
 }
 

--- a/src/main/java/com/example/Triple_clone/service/report/ReportEventListener.java
+++ b/src/main/java/com/example/Triple_clone/service/report/ReportEventListener.java
@@ -1,5 +1,6 @@
 package com.example.Triple_clone.service.report;
 
+import com.example.Triple_clone.domain.vo.NotificationTarget;
 import com.example.Triple_clone.domain.vo.NotificationType;
 import com.example.Triple_clone.dto.notification.NotificationDto;
 import com.example.Triple_clone.dto.report.ReportCreatedEvent;
@@ -21,6 +22,7 @@ public class ReportEventListener {
     public void handleReportCreated(ReportCreatedEvent event) {
         notificationEventService.notify(new NotificationDto(
                 NotificationType.REPORT_ALERT,
+                NotificationTarget.ADMIN,
                 event
         ));
     }

--- a/src/main/java/com/example/Triple_clone/service/report/ReportEventListener.java
+++ b/src/main/java/com/example/Triple_clone/service/report/ReportEventListener.java
@@ -3,7 +3,7 @@ package com.example.Triple_clone.service.report;
 import com.example.Triple_clone.domain.vo.NotificationType;
 import com.example.Triple_clone.dto.notification.NotificationDto;
 import com.example.Triple_clone.dto.report.ReportCreatedEvent;
-import com.example.Triple_clone.service.notification.NotificationService;
+import com.example.Triple_clone.service.notification.NotificationEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -14,12 +14,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class ReportEventListener {
 
-    private final NotificationService notificationService;
+    private final NotificationEventService notificationEventService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @EventListener
     public void handleReportCreated(ReportCreatedEvent event) {
-        notificationService.notify(new NotificationDto(
+        notificationEventService.notify(new NotificationDto(
                 NotificationType.REPORT_ALERT,
                 event
         ));

--- a/src/main/java/com/example/Triple_clone/web/controller/notification/NotificationController.java
+++ b/src/main/java/com/example/Triple_clone/web/controller/notification/NotificationController.java
@@ -1,0 +1,29 @@
+package com.example.Triple_clone.web.controller.notification;
+
+import com.example.Triple_clone.dto.notification.NotificationSearchDto;
+import com.example.Triple_clone.service.notification.NotificationService;
+import com.example.Triple_clone.web.support.MemberEmailAspect;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/notifications")
+    public List<NotificationSearchDto> getNotifications(@MemberEmailAspect String email) {
+        return notificationService.getUserNotifications(email);
+    }
+
+    @PostMapping("notifications/read/{memberId}")
+    public ResponseEntity<Void> markAsRead(@PathVariable Long memberId,
+                                           @MemberEmailAspect String email) {
+        notificationService.markAsRead(email, memberId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/test/java/com/example/Triple_clone/service/notification/NotificationEventServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/notification/NotificationEventServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.Triple_clone.service.notification;
 
+import com.example.Triple_clone.domain.vo.NotificationTarget;
 import com.example.Triple_clone.domain.vo.NotificationType;
 import com.example.Triple_clone.dto.notification.NotificationDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +30,7 @@ class NotificationEventServiceTest {
 
     @Test
     void notify_callsSend_onSupportingSender() {
-        NotificationDto event = new NotificationDto(NotificationType.REPORT_ALERT, "payload");
+        NotificationDto event = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, "payload");
 
         when(sender1.supports(NotificationType.REPORT_ALERT)).thenReturn(true);
         when(sender2.supports(NotificationType.REPORT_ALERT)).thenReturn(false);

--- a/src/test/java/com/example/Triple_clone/service/notification/NotificationEventServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/notification/NotificationEventServiceTest.java
@@ -37,7 +37,7 @@ class NotificationEventServiceTest {
 
         notificationEventService.notify(event);
 
-        verify(sender1, times(1)).send(event);
-        verify(sender2, never()).send(any());
+        verify(sender1, times(1)).process(event);
+        verify(sender2, never()).process(any());
     }
 }

--- a/src/test/java/com/example/Triple_clone/service/notification/NotificationEventServiceTest.java
+++ b/src/test/java/com/example/Triple_clone/service/notification/NotificationEventServiceTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.*;
 
-class NotificationServiceTest {
+class NotificationEventServiceTest {
 
     @Mock
     private NotificationSender sender1;
@@ -19,12 +19,12 @@ class NotificationServiceTest {
     @Mock
     private NotificationSender sender2;
 
-    private NotificationService notificationService;
+    private NotificationEventService notificationEventService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        notificationService = new NotificationService(List.of(sender1, sender2));
+        notificationEventService = new NotificationEventService(List.of(sender1, sender2));
     }
 
     @Test
@@ -34,7 +34,7 @@ class NotificationServiceTest {
         when(sender1.supports(NotificationType.REPORT_ALERT)).thenReturn(true);
         when(sender2.supports(NotificationType.REPORT_ALERT)).thenReturn(false);
 
-        notificationService.notify(event);
+        notificationEventService.notify(event);
 
         verify(sender1, times(1)).send(event);
         verify(sender2, never()).send(any());

--- a/src/test/java/com/example/Triple_clone/service/notification/ReportNotificationSenderTest.java
+++ b/src/test/java/com/example/Triple_clone/service/notification/ReportNotificationSenderTest.java
@@ -8,7 +8,6 @@ import com.example.Triple_clone.dto.notification.NotificationDto;
 import com.example.Triple_clone.dto.notification.NotificationMessage;
 import com.example.Triple_clone.dto.report.ReportCreatedEvent;
 import com.example.Triple_clone.repository.AdminNotificationSettingRepository;
-import com.example.Triple_clone.service.notification.channel.ChannelNotificationSender;
 import com.example.Triple_clone.service.notification.channel.EmailNotificationSender;
 import com.example.Triple_clone.web.support.HtmlTemplateRenderer;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,7 +78,7 @@ class ReportNotificationSenderTest {
         when(event.report()).thenReturn(report);
         when(event.reportCount()).thenReturn(3L);
 
-        NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, event);
+        NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, event);
 
         reportNotificationSender.send(dto);
 
@@ -113,7 +112,7 @@ class ReportNotificationSenderTest {
         when(event.report()).thenReturn(report);
         when(event.reportCount()).thenReturn(10L);
 
-        NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, event);
+        NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, event);
 
         reportNotificationSender.send(dto);
 
@@ -145,7 +144,7 @@ class ReportNotificationSenderTest {
         when(event.report()).thenReturn(report);
         when(event.reportCount()).thenReturn(3L);
 
-        NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, event);
+        NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, event);
 
         reportNotificationSender.send(dto);
 
@@ -179,7 +178,7 @@ class ReportNotificationSenderTest {
         when(event.report()).thenReturn(report);
         when(event.reportCount()).thenReturn(3L);
 
-        NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, event);
+        NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, event);
 
         assertThatThrownBy(() -> reportNotificationSender.send(dto))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/example/Triple_clone/service/notification/ReportNotificationSenderTest.java
+++ b/src/test/java/com/example/Triple_clone/service/notification/ReportNotificationSenderTest.java
@@ -24,7 +24,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 class ReportNotificationSenderTest {
-
+    @Mock
+    private NotificationSaveService notificationSaveService;
     @Mock
     private AdminNotificationSettingRepository settingRepository;
 
@@ -41,6 +42,7 @@ class ReportNotificationSenderTest {
         reportNotificationSender = new ReportNotificationSender(
                 htmlTemplateRenderer,
                 List.of(emailSender),
+                notificationSaveService,
                 settingRepository
         );
     }
@@ -80,7 +82,7 @@ class ReportNotificationSenderTest {
 
         NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, event);
 
-        reportNotificationSender.send(dto);
+        reportNotificationSender.prepareAndSend(dto);
 
         verify(emailSender).send(any(NotificationMessage.class));
     }
@@ -114,7 +116,7 @@ class ReportNotificationSenderTest {
 
         NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, event);
 
-        reportNotificationSender.send(dto);
+        reportNotificationSender.prepareAndSend(dto);
 
         verify(emailSender).send(any(NotificationMessage.class));
     }
@@ -146,7 +148,7 @@ class ReportNotificationSenderTest {
 
         NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, event);
 
-        reportNotificationSender.send(dto);
+        reportNotificationSender.prepareAndSend(dto);
 
         verifyNoInteractions(emailSender);
     }
@@ -180,7 +182,7 @@ class ReportNotificationSenderTest {
 
         NotificationDto dto = new NotificationDto(NotificationType.REPORT_ALERT, NotificationTarget.PERSONAL, event);
 
-        assertThatThrownBy(() -> reportNotificationSender.send(dto))
+        assertThatThrownBy(() -> reportNotificationSender.prepareAndSend(dto))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("지원하지 않는 채널 타입입니다");
     }


### PR DESCRIPTION
# 📨 알림 히스토리 저장 기능 구현 PR

## 📌 주요 변경 사항

### 1️⃣ 알림 히스토리 저장 기능 추가
- 알림 전송 시 `Notification` Entity 저장
- 사용자별 알림 읽음 상태를 관리하는 `NotificationStatus` Entity 저장

### 2️⃣ 알림 대상에 따라 유연한 처리
- `NotificationTarget`이 `GLOBAL`인 경우: 전체 사용자(`USER` 권한) 대상 알림 상태 저장
- `PERSONAL`, `ADMIN` 대상 알림의 경우: 명시된 사용자 목록에만 알림 상태 저장

### 3️⃣ 구조적 개선
- 템플릿 메서드 패턴을 적용시켜 알림 전송시 저장 로직 강제화
- 알림 전송과 상태 저장을 분리하여 **배치 처리 고려**
- 추후 저장 방식 최적화 및 유지보수 용이